### PR TITLE
Port multiserver-dht to Hyperswarm

### DIFF
--- a/example-s.js
+++ b/example-s.js
@@ -2,7 +2,8 @@ var pull = require('pull-stream');
 var MultiServer = require('multiserver');
 var Dht = require('./index');
 
-var ms = MultiServer([Dht({keys: pull.values(['brazil', 'germany'])})]);
+// var ms = MultiServer([Dht({keys: pull.values(['brazil', 'germany'])})]);
+var ms = MultiServer([Dht({key: 'brazil'})]);
 
 ms.server(function(stream, info) {
   console.log('server got a client');

--- a/example-s.js
+++ b/example-s.js
@@ -3,7 +3,7 @@ var MultiServer = require('multiserver');
 var Dht = require('./index');
 
 // var ms = MultiServer([Dht({keys: pull.values(['brazil', 'germany'])})]);
-var ms = MultiServer([Dht({key: 'brazil'})]);
+var ms = MultiServer([Dht({key: 'germany'})]);
 
 ms.server(function(stream, info) {
   console.log('server got a client');

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var pull = require('pull-stream');
 var toPull = require('stream-to-pull-stream');
 var datDefaults = require('dat-swarm-defaults');
-var swarm = require('hyperswarm-web');
+var swarm = require('hyperswarm');
 var crypto = require('crypto');
 
 function createPeer(_opts) {
@@ -9,9 +9,10 @@ function createPeer(_opts) {
   delete swarmOpts.key;
   delete swarmOpts.keys;
 
-  swarmOpts.bootstrap = ['ws://hyperswarm.mauve.moe']
+  //swarmOpts.bootstrap = ['ws://hyperswarm.mauve.moe']
+  //swarmOpts.bootstrap = ['ws://localhost:4977']
 
-  var sw = swarm(datDefaults(swarmOpts));
+  var sw = swarm(swarmOpts) //swarm(datDefaults(swarmOpts));
   return sw;
 }
 
@@ -38,7 +39,7 @@ function updateChannelsToHost(onError, serverCfg) {
     newChannels.forEach(channel => {
       if (!oldChannels.has(channel)) {
         serverCfg.channels.add(channel);
-        serverCfg.peer.join(crypto.createHash('sha256').update(channel).digest(), { lookup: false, announce: true });
+        serverCfg.peer.join(crypto.createHash('sha256').update(channel).digest(), { lookup: true, announce: true });
       }
     });
 
@@ -154,7 +155,7 @@ module.exports = function makePlugin(opts) {
           cb(err);
         }
       };
-      clientPeer.join(crypto.createHash('sha256').update(channel).digest(), { lookup: true, announce: false });
+      clientPeer.join(crypto.createHash('sha256').update(channel).digest(), { lookup: true, announce: true });
       clientPeer.on('connection', listener);
       clientPeer.on('connection-closed', (conn, info) => {
         if (connected) {

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = function makePlugin(opts) {
 
       function lazilyCreateServerPeer(channelsArr) {
         if (channelsArr.length > 0 && !serverCfg.peer) {
-	  opts.ephemeral = false;
+          opts.ephemeral = false;
           serverCfg.peer = createPeer(opts);
           serverCfg.listener = (socket, info) => {
             const stream = toPull.duplex(socket);
@@ -152,6 +152,7 @@ module.exports = function makePlugin(opts) {
         if (err) {
           clientPeer.removeListener('connection', listener);
           clientPeer.leave(channelToBuf(channel));
+          clientPeer.destroy((err) => {})
           cb(err);
         }
       };
@@ -165,6 +166,7 @@ module.exports = function makePlugin(opts) {
       });
 
       return () => {
+        clientPeer.destroy((err) => {})
       };
     },
 

--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
 var pull = require('pull-stream');
 var toPull = require('stream-to-pull-stream');
 var datDefaults = require('dat-swarm-defaults');
-var swarm = require('hyperswarm');
+var swarm = require('hyperswarm-web');
 var crypto = require('crypto');
 
 function createPeer(_opts) {
   var swarmOpts = Object.assign({}, _opts || {});
   delete swarmOpts.key;
   delete swarmOpts.keys;
+
+  swarmOpts.bootstrap = ['ws://hyperswarm.mauve.moe']
 
   var sw = swarm(datDefaults(swarmOpts));
   return sw;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,24 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@geut/discovery-swarm-webrtc": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@geut/discovery-swarm-webrtc/-/discovery-swarm-webrtc-2.2.7.tgz",
+      "integrity": "sha512-adb4pMiuho9TbyIztS6+uw0aAQxFkp7MtYhwm4BEHxXUQ0WjwNNAWRPKGKCKc/d4dCiDJHF1e/o63HAQHI5TnQ==",
+      "requires": {
+        "debug": "^4.1.1",
+        "delay": "^4.3.0",
+        "minimist": "^1.2.0",
+        "mostly-minimal-spanning-tree": "^1.0.1",
+        "p-debounce": "^2.1.0",
+        "p-forever": "^2.1.0",
+        "pump": "^3.0.0",
+        "simple-signal-client": "^2.3.1",
+        "simple-signal-server": "^2.1.1",
+        "socket.io": "^2.2.0",
+        "socket.io-client": "^2.2.0"
+      }
+    },
     "@hyperswarm/dht": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@hyperswarm/dht/-/dht-4.0.1.tgz",
@@ -79,11 +97,81 @@
         "utp-native": "^2.2.1"
       }
     },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+    },
+    "arraybuffer.slice": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
+    },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
+      }
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base64-arraybuffer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
     },
     "blake2b": {
       "version": "2.1.3",
@@ -127,6 +215,11 @@
         "nanoassert": "^1.0.0"
       }
     },
+    "blob": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -136,6 +229,34 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "chloride": {
       "version": "2.2.8",
@@ -164,11 +285,46 @@
       "resolved": "https://registry.npmjs.org/codecs/-/codecs-2.2.0.tgz",
       "integrity": "sha512-+xi2ENsvchtUNa8oBUU58gHgmyN6BEEeZ8NIEgeQ0XnC+AoyihivgZYe+OOiNi+fLy/NUowugwV5gP8XWYDm0Q=="
     },
+    "component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+    },
+    "component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
+    "core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cuid": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
+      "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg=="
     },
     "dat-swarm-defaults": {
       "version": "1.0.1",
@@ -176,6 +332,14 @@
       "integrity": "sha512-T2WlO7BVmN9USchefsP8entQiByIlJLGuzHLL9qEqOBkyKB8p0Y7XPWxP8dcL43+SkeoxU5NVe7O0bsi3xL8Jg==",
       "requires": {
         "xtend": "^4.0.1"
+      }
+    },
+    "debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "requires": {
+        "ms": "2.1.2"
       }
     },
     "deep-equal": {
@@ -199,6 +363,21 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
+    },
+    "delay": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.0.tgz",
+      "integrity": "sha512-txgOrJu3OdtOfTiEOT2e76dJVfG/1dz2NZ4F0Pyt4UGZJryssMRp5vdM5wQoLwSOBNdrJv3F9PAhp/heqd7vrA=="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "dht-rpc": {
       "version": "4.9.6",
@@ -242,6 +421,83 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "duplexpair": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/duplexpair/-/duplexpair-1.0.1.tgz",
+      "integrity": "sha512-xAJCL8UnXa+GyHIqSNUT9eiQSfGvSBPOZvAYN17ULwYBMady5Ek6Ghpuj4P6+ZGkjlmUFdTh9y+ejvKRl5rcRg==",
+      "requires": {
+        "readable-stream": "^2.3.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "ed2curve": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
@@ -251,6 +507,16 @@
         "tweetnacl": "0.x.x"
       }
     },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -258,6 +524,97 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "end-of-stream-promise": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream-promise/-/end-of-stream-promise-1.0.0.tgz",
+      "integrity": "sha512-1u3Geul15xPtCiZFZibKWulA6pMecvPO+cvejugP36fGviKdcKydXzHMLqjZgt+N+DO+ifcKVUYcmg7IxlgpBg==",
+      "requires": {
+        "end-of-stream": "^1.4.4"
+      }
+    },
+    "engine.io": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.5.0.tgz",
+      "integrity": "sha512-21HlvPUKaitDGE4GXNtQ7PLP0Sz4aWLddMPw2VTyFz1FVZqu/kZsJUO8WNpKuE/OCL7nkfRaOui2ZCJloGznGA==",
+      "requires": {
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "debug": "~4.1.0",
+        "engine.io-parser": "~2.2.0",
+        "ws": "~7.4.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ws": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+          "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
+        }
+      }
+    },
+    "engine.io-client": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.0.tgz",
+      "integrity": "sha512-12wPRfMrugVw/DNyJk34GQ5vIVArEcVMXWugQGGuw2XxUSztFNmJggZmv8IZlLyEdnpO1QB9LkcjeWewO2vxtA==",
+      "requires": {
+        "component-emitter": "~1.3.0",
+        "component-inherit": "0.0.3",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.2.0",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
+        "ws": "~7.4.2",
+        "xmlhttprequest-ssl": "~1.5.4",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "ws": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+          "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
+      "integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "~0.0.7",
+        "base64-arraybuffer": "0.1.4",
+        "blob": "0.0.5",
+        "has-binary2": "~1.0.2"
+      }
+    },
+    "err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "es-abstract": {
       "version": "1.11.0",
@@ -283,6 +640,21 @@
         "is-symbol": "^1.0.1"
       }
     },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "for-each": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
@@ -298,6 +670,11 @@
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -309,6 +686,11 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "get-browser-rtc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
+      "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ=="
     },
     "glob": {
       "version": "7.1.2",
@@ -338,10 +720,42 @@
         "function-bind": "^1.0.2"
       }
     },
+    "has-binary2": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+      "requires": {
+        "isarray": "2.0.1"
+      }
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+    },
     "hashlru": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
       "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
+    },
+    "http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
+      }
     },
     "hyperswarm": {
       "version": "2.15.2",
@@ -353,11 +767,104 @@
         "utp-native": "^2.1.7"
       }
     },
+    "hyperswarm-proxy": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/hyperswarm-proxy/-/hyperswarm-proxy-1.4.0.tgz",
+      "integrity": "sha512-1YAEHbmsATQ6E6G52iRFVIWmxIGmmwem+gJZwfhWBWdJM/+/SmN7DFaCBuGgPWgkf05Hcq1JyHCNgpXXLOsxJQ==",
+      "requires": {
+        "@hyperswarm/network": "^1.3.2",
+        "length-prefixed-stream": "^2.0.0",
+        "pump": "^3.0.0"
+      },
+      "dependencies": {
+        "@hyperswarm/dht": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/@hyperswarm/dht/-/dht-3.6.5.tgz",
+          "integrity": "sha512-SJL3cVG0ahecikal+Xv4+AbUYo/PVcymD36bX7C71E3Q3iUR5eNntXRoZP0BgOklMFT/x5rzkHy6HJYYxPa7pQ==",
+          "requires": {
+            "@hyperswarm/hypersign": "^2.0.0",
+            "dht-rpc": "^4.8.0",
+            "end-of-stream": "^1.4.1",
+            "guard-timeout": "^2.0.0",
+            "hashlru": "^2.3.0",
+            "protocol-buffers-encodings": "^1.1.0",
+            "record-cache": "^1.1.0",
+            "sodium-native": "^3.1.1",
+            "uint64be": "^2.0.2"
+          }
+        },
+        "@hyperswarm/discovery": {
+          "version": "1.11.5",
+          "resolved": "https://registry.npmjs.org/@hyperswarm/discovery/-/discovery-1.11.5.tgz",
+          "integrity": "sha512-C5Hbq31lkfrjFytuujSxzvied3PzDU98xeKs34oW/D7NIexGM13dqKC8mMDxkxkqXDMzx/vKrwvD/Jfd+q79uQ==",
+          "requires": {
+            "@hyperswarm/dht": "^3.2.0",
+            "multicast-dns": "^7.2.0",
+            "timeout-refresh": "^1.0.2"
+          }
+        },
+        "@hyperswarm/network": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/@hyperswarm/network/-/network-1.5.1.tgz",
+          "integrity": "sha512-qjVLlZ0OVCD4RFnsxhxuSGgb50EyXD3twA/togLfWypGpT8t0VheB0NH7SMQjyru/cX+safESqn+qr0AcvcYOw==",
+          "requires": {
+            "@hyperswarm/discovery": "^1.6.0",
+            "nanoresource": "^1.0.0",
+            "utp-native": "^2.1.3"
+          }
+        },
+        "node-gyp-build": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+        },
+        "sodium-native": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
+          "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
+          "requires": {
+            "ini": "^1.3.5",
+            "node-gyp-build": "^4.2.0"
+          }
+        }
+      }
+    },
+    "hyperswarm-proxy-ws": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperswarm-proxy-ws/-/hyperswarm-proxy-ws-1.2.0.tgz",
+      "integrity": "sha512-kX7wjsXjxIv496CpqlKtdikqeHMNEzx5+oJQJaj8pKIOdhdD/Rkbb/w6fy1dQhEKEyXK0N/oPnRBXqNXnbnxhw==",
+      "requires": {
+        "hyperswarm-proxy": "^1.4.0",
+        "websocket-stream": "^5.5.0"
+      }
+    },
+    "hyperswarm-web": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hyperswarm-web/-/hyperswarm-web-1.0.3.tgz",
+      "integrity": "sha512-DxBGpmk2FoeZYcT/BNkmaVpMBuHECwjZzGFy+h6E7cyfo89TBOwDOYAJJ2W2oNJveoQg/fvtyg9tvcGxa0yzcQ==",
+      "requires": {
+        "@geut/discovery-swarm-webrtc": "^2.2.4",
+        "duplexpair": "^1.0.1",
+        "hyperswarm-proxy-ws": "^1.0.0",
+        "minimist": "^1.2.0",
+        "send": "^0.17.1"
+      }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "increment-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/increment-buffer/-/increment-buffer-1.0.1.tgz",
       "integrity": "sha1-ZQdtdRidgIs5rROrW5WOBSFvng0=",
       "dev": true
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "inflight": {
       "version": "1.0.6",
@@ -428,6 +935,11 @@
       "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
+    "isarray": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+      "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+    },
     "json-buffer": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz",
@@ -440,6 +952,16 @@
       "integrity": "sha512-r/q+wV/Kde62/tk+rqyttEJn6h0jR7x+incdMVSYTqK73zVxVrzJa70kJL49cIKen8XjIgUZKSvk8ktnrQbK4w==",
       "requires": {
         "randombytes": "^2.0.3"
+      }
+    },
+    "length-prefixed-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/length-prefixed-stream/-/length-prefixed-stream-2.0.0.tgz",
+      "integrity": "sha512-dvjTuWTKWe0oEznQcG6a9osfiYknCs7DEFJMP88n9Y581IFhYh1sZIgAFcuDOojKB0G7ftPreKhh4D0kh/VPjQ==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "varint": "^5.0.0"
       }
     },
     "libsodium": {
@@ -462,6 +984,24 @@
       "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
       "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
     },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "mime-db": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
+    },
+    "mime-types": {
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+      "requires": {
+        "mime-db": "1.45.0"
+      }
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -474,8 +1014,25 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mostly-minimal-spanning-tree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mostly-minimal-spanning-tree/-/mostly-minimal-spanning-tree-1.0.2.tgz",
+      "integrity": "sha512-jSEpLlBDyRHEjVaUHe037a/XXcwxtlyyv6zKq4zAN90XjyGXzOnL/o3TSStip/rBh+NTtCAq3OY6WlkQWH8hxQ==",
+      "requires": {
+        "delay": "^4.3.0",
+        "end-of-stream-promise": "^1.0.0",
+        "p-queue": "^6.3.0",
+        "promise-defer": "^1.0.0",
+        "randomize-array": "^1.2.0",
+        "xor-distance": "^2.0.0"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
       "version": "7.2.2",
@@ -531,6 +1088,16 @@
       "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
       "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
     },
+    "nanobus": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/nanobus/-/nanobus-4.4.0.tgz",
+      "integrity": "sha512-Hv9USGyH8EsPy0o8pPWE7x3YRIfuZDgMBirzjU6XLebhiSK2g53JlfqgolD0c39ne6wXAfaBNcIAvYe22Bav+Q==",
+      "requires": {
+        "nanoassert": "^1.1.0",
+        "nanotiming": "^7.2.0",
+        "remove-array-items": "^1.0.0"
+      }
+    },
     "nanoresource": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/nanoresource/-/nanoresource-1.3.0.tgz",
@@ -546,10 +1113,32 @@
         }
       }
     },
+    "nanoscheduler": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/nanoscheduler/-/nanoscheduler-1.0.3.tgz",
+      "integrity": "sha512-jBbrF3qdU9321r8n9X7yu18DjP31Do2ItJm3mWrt90wJTrnDO+HXpoV7ftaUglAtjgj9s+OaCxGufbvx6pvbEQ==",
+      "requires": {
+        "nanoassert": "^1.1.0"
+      }
+    },
+    "nanotiming": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/nanotiming/-/nanotiming-7.3.1.tgz",
+      "integrity": "sha512-l3lC7v/PfOuRWQa8vV29Jo6TG10wHtnthLElFXs4Te4Aas57Fo4n1Q8LH9n+NDh9riOzTVvb2QNBhTS4JUKNjw==",
+      "requires": {
+        "nanoassert": "^1.1.0",
+        "nanoscheduler": "^1.0.2"
+      }
+    },
     "napi-macros": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
       "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "node-gyp-build": {
       "version": "3.3.0",
@@ -570,6 +1159,14 @@
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
     },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -584,6 +1181,48 @@
       "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
       "dev": true
     },
+    "p-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-debounce/-/p-debounce-2.1.0.tgz",
+      "integrity": "sha512-M9bMt62TTnozdZhqFgs+V7XD2MnuKCaz+7fZdlu2/T7xruI3uIE5CicQ0vx1hV7HIUYF0jF+4/R1AgfOkl74Qw=="
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-forever": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-forever/-/p-forever-2.1.0.tgz",
+      "integrity": "sha512-kqZrNBsD8fUPCpZLYJoHTiONQVrdkA2nKwSsTfIr5h7P8jGpSy+Vzkxu6nVcZcz3c/rSx/Ys3AACd/BkMKvqbw=="
+    },
+    "p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
+    "parseqs": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+      "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
+    },
+    "parseuri": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -595,6 +1234,16 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "promise-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promise-defer/-/promise-defer-1.0.0.tgz",
+      "integrity": "sha1-JagJPxm6tAxiqORkyX0E/kzcCiQ="
     },
     "protocol-buffers-encodings": {
       "version": "1.1.1",
@@ -680,6 +1329,20 @@
         "ws": "^1.1.0"
       }
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "queue-microtask": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
+      "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -687,6 +1350,16 @@
       "requires": {
         "safe-buffer": "^5.1.0"
       }
+    },
+    "randomize-array": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/randomize-array/-/randomize-array-1.2.0.tgz",
+      "integrity": "sha512-3utyf30rF+wc1ZPgl+lTn8WMMGyMNN0uQkyuWo3N/vVT3J2Olt1ymCk3J8+zl4dsvYnplLFd+CLnYlCLT1W0iw=="
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "readable-stream": {
       "version": "3.6.0",
@@ -703,11 +1376,21 @@
       "resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.1.0.tgz",
       "integrity": "sha512-u8rbtLEJV7HRacl/ZYwSBFD8NFyB3PfTTfGLP37IW3hftQCwu6z4Q2RLyxo1YJUNRTEzJfpLpGwVuEYdaIkG9Q=="
     },
+    "regenerator-runtime": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+    },
     "relative-url": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
       "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc=",
       "dev": true
+    },
+    "remove-array-items": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
+      "integrity": "sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA=="
     },
     "resolve": {
       "version": "1.5.0",
@@ -745,11 +1428,58 @@
         "pull-stream": "^3.4.5"
       }
     },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "separator-escape": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/separator-escape/-/separator-escape-0.0.0.tgz",
       "integrity": "sha1-5DNnaTICBFTjwUhwxRfqHeVsL6Q=",
       "dev": true
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "sha.js": {
       "version": "2.4.5",
@@ -774,6 +1504,137 @@
       "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
       "requires": {
         "varint": "~5.0.0"
+      }
+    },
+    "simple-peer": {
+      "version": "9.9.3",
+      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.9.3.tgz",
+      "integrity": "sha512-T3wuv0UqBpDTV0x0pJPPsz4thy0tC0fTOHE4g9+AF43RUxxT+MWeXVtdQcK5Xuzv/XTVrB2NrGzdfO1IFBqOkw==",
+      "requires": {
+        "buffer": "^6.0.2",
+        "debug": "^4.2.0",
+        "err-code": "^2.0.3",
+        "get-browser-rtc": "^1.0.2",
+        "queue-microtask": "^1.2.0",
+        "randombytes": "^2.1.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "simple-signal-client": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/simple-signal-client/-/simple-signal-client-2.3.1.tgz",
+      "integrity": "sha512-G1w2Ya4+scKah6mXkU6EZogo896uobgcnnWqgqYN1vJsF6o5IAjj9ZNSuoj82F9CNPSPKazie3Wmv+0eNYkVGQ==",
+      "requires": {
+        "babel-polyfill": "^6.23.0",
+        "cuid": "^2.0.2",
+        "inherits": "^2.0.3",
+        "nanobus": "^4.3.3",
+        "simple-peer": "^9.6.2"
+      }
+    },
+    "simple-signal-server": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/simple-signal-server/-/simple-signal-server-2.1.2.tgz",
+      "integrity": "sha512-9754Rww59LSSXWH+DjnYzFBoFzxN9fY1vouqVeBs/YFpTycMCtYb1JHihzrBfmajaP5g9d/1rWOHS7svCyqbiA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "nanobus": "^4.3.3"
+      }
+    },
+    "socket.io": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.4.1.tgz",
+      "integrity": "sha512-Si18v0mMXGAqLqCVpTxBa8MGqriHGQh8ccEOhmsmNS3thNCGBwO8WGrwMibANsWtQQ5NStdZwHqZR3naJVFc3w==",
+      "requires": {
+        "debug": "~4.1.0",
+        "engine.io": "~3.5.0",
+        "has-binary2": "~1.0.2",
+        "socket.io-adapter": "~1.1.0",
+        "socket.io-client": "2.4.0",
+        "socket.io-parser": "~3.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
+      "integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g=="
+    },
+    "socket.io-client": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.4.0.tgz",
+      "integrity": "sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==",
+      "requires": {
+        "backo2": "1.0.2",
+        "component-bind": "1.0.0",
+        "component-emitter": "~1.3.0",
+        "debug": "~3.1.0",
+        "engine.io-client": "~3.5.0",
+        "has-binary2": "~1.0.2",
+        "indexof": "0.0.1",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
+        "socket.io-parser": "~3.3.0",
+        "to-array": "0.1.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "socket.io-parser": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
+          "integrity": "sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==",
+          "requires": {
+            "component-emitter": "~1.3.0",
+            "debug": "~3.1.0",
+            "isarray": "2.0.1"
+          }
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.1.tgz",
+      "integrity": "sha512-11hMgzL+WCLWf1uFtHSNvliI++tcRUWdoeYuwIl+Axvwy9z2gQM+7nJyN3STj1tLj5JyIUH8/gpDGxzAlDdi0A==",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "debug": "~4.1.0",
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "sodium-browserify": {
@@ -841,6 +1702,11 @@
       "integrity": "sha1-t+jgq1E0UVi3LB9tvvJAbVHx0Cc=",
       "dev": true
     },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
     "stream-collector": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-collector/-/stream-collector-1.0.1.tgz",
@@ -848,6 +1714,11 @@
       "requires": {
         "once": "^1.3.1"
       }
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "stream-to-pull-stream": {
       "version": "1.7.2",
@@ -926,6 +1797,16 @@
       "resolved": "https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-1.0.3.tgz",
       "integrity": "sha512-Mz0CX4vBGM5lj8ttbIFt7o4ZMxk/9rgudJRh76EvB7xXZMur7T/cjRiH2w4Fmkq0zxf2QpM8IFvOSRn8FEu3gA=="
     },
+    "to-array": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -939,6 +1820,14 @@
       "dev": true,
       "requires": {
         "tweetnacl": "0.x.x"
+      }
+    },
+    "uint64be": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uint64be/-/uint64be-2.0.2.tgz",
+      "integrity": "sha512-9QqdvpGQTXgxthP+lY4e/gIBy+RuqcBaC6JVwT5I3bDLgT/btL6twZMR0pI3/Fgah9G/pdwzIprE5gL6v9UvyQ==",
+      "requires": {
+        "buffer-alloc": "^1.1.0"
       }
     },
     "ultron": {
@@ -981,6 +1870,89 @@
       "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
       "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
     },
+    "websocket-stream": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/websocket-stream/-/websocket-stream-5.5.2.tgz",
+      "integrity": "sha512-8z49MKIHbGk3C4HtuHWDtYX8mYej1wWabjthC/RupM9ngeukU4IWoM46dgth1UOS/T4/IqgEdCDJuMe2039OQQ==",
+      "requires": {
+        "duplexify": "^3.5.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.3",
+        "safe-buffer": "^5.1.2",
+        "ws": "^3.2.0",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        },
+        "ultron": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+        },
+        "ws": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -996,6 +1968,11 @@
         "ultron": "1.0.x"
       }
     },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+    },
     "xor-distance": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xor-distance/-/xor-distance-2.0.0.tgz",
@@ -1005,6 +1982,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,21 +5,18 @@
   "requires": true,
   "dependencies": {
     "@geut/discovery-swarm-webrtc": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@geut/discovery-swarm-webrtc/-/discovery-swarm-webrtc-2.2.7.tgz",
-      "integrity": "sha512-adb4pMiuho9TbyIztS6+uw0aAQxFkp7MtYhwm4BEHxXUQ0WjwNNAWRPKGKCKc/d4dCiDJHF1e/o63HAQHI5TnQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@geut/discovery-swarm-webrtc/-/discovery-swarm-webrtc-4.1.0.tgz",
+      "integrity": "sha512-6uboP3t9bV87SPksK1IWy5BxHSKuXsD3VwY/NF5jMKUVL346I+dkoepNlr/CxzXvY1BkJRtsnTZKgBz4PPJgjA==",
       "requires": {
         "debug": "^4.1.1",
-        "delay": "^4.3.0",
+        "end-of-stream": "^1.4.4",
         "minimist": "^1.2.0",
-        "mostly-minimal-spanning-tree": "^1.0.1",
-        "p-debounce": "^2.1.0",
-        "p-forever": "^2.1.0",
+        "mostly-minimal-spanning-tree": "^1.0.2",
+        "nanocustomassert": "^1.0.0",
+        "nanoerror": "^1.1.0",
         "pump": "^3.0.0",
-        "simple-signal-client": "^2.3.1",
-        "simple-signal-server": "^2.1.1",
-        "socket.io": "^2.2.0",
-        "socket.io-client": "^2.2.0"
+        "socket-signal-websocket": "^9.0.0"
       }
     },
     "@hyperswarm/dht": {
@@ -97,60 +94,10 @@
         "utp-native": "^2.2.1"
       }
     },
-    "accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-      "requires": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
-      }
-    },
-    "after": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
-    },
-    "arraybuffer.slice": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
-    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
-    },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        }
-      }
-    },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -158,20 +105,10 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "base64-arraybuffer": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
-      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
-    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
-    "base64id": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
     },
     "blake2b": {
       "version": "2.1.3",
@@ -214,11 +151,6 @@
       "requires": {
         "nanoassert": "^1.0.0"
       }
-    },
-    "blob": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
-      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -285,46 +217,16 @@
       "resolved": "https://registry.npmjs.org/codecs/-/codecs-2.2.0.tgz",
       "integrity": "sha512-+xi2ENsvchtUNa8oBUU58gHgmyN6BEEeZ8NIEgeQ0XnC+AoyihivgZYe+OOiNi+fLy/NUowugwV5gP8XWYDm0Q=="
     },
-    "component-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
-    },
-    "component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
-    },
-    "component-inherit": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
-    },
-    "core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cuid": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
-      "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg=="
     },
     "dat-swarm-defaults": {
       "version": "1.0.1",
@@ -432,11 +334,6 @@
         "stream-shift": "^1.0.0"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -469,11 +366,6 @@
         "readable-stream": "^2.3.3"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -512,6 +404,11 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "emittery": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.6.0.tgz",
+      "integrity": "sha512-6EMRGr9KzYWp8DzHFZsKVZBsMO6QhAeHMeHND8rhyBNCHKMLpgW9tZv40bwN3rAIKRS5CxcK8oLRKUJSB9h7yQ=="
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -531,84 +428,6 @@
       "integrity": "sha512-1u3Geul15xPtCiZFZibKWulA6pMecvPO+cvejugP36fGviKdcKydXzHMLqjZgt+N+DO+ifcKVUYcmg7IxlgpBg==",
       "requires": {
         "end-of-stream": "^1.4.4"
-      }
-    },
-    "engine.io": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.5.0.tgz",
-      "integrity": "sha512-21HlvPUKaitDGE4GXNtQ7PLP0Sz4aWLddMPw2VTyFz1FVZqu/kZsJUO8WNpKuE/OCL7nkfRaOui2ZCJloGznGA==",
-      "requires": {
-        "accepts": "~1.3.4",
-        "base64id": "2.0.0",
-        "cookie": "~0.4.1",
-        "debug": "~4.1.0",
-        "engine.io-parser": "~2.2.0",
-        "ws": "~7.4.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ws": {
-          "version": "7.4.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-          "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
-        }
-      }
-    },
-    "engine.io-client": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.0.tgz",
-      "integrity": "sha512-12wPRfMrugVw/DNyJk34GQ5vIVArEcVMXWugQGGuw2XxUSztFNmJggZmv8IZlLyEdnpO1QB9LkcjeWewO2vxtA==",
-      "requires": {
-        "component-emitter": "~1.3.0",
-        "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.2.0",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parseqs": "0.0.6",
-        "parseuri": "0.0.6",
-        "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.5.4",
-        "yeast": "0.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "ws": {
-          "version": "7.4.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-          "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
-        }
-      }
-    },
-    "engine.io-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
-      "integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
-      "requires": {
-        "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
-        "base64-arraybuffer": "0.1.4",
-        "blob": "0.0.5",
-        "has-binary2": "~1.0.2"
       }
     },
     "err-code": {
@@ -654,6 +473,14 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "fastq": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
+      "integrity": "sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==",
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "for-each": {
       "version": "0.3.2",
@@ -719,19 +546,6 @@
       "requires": {
         "function-bind": "^1.0.2"
       }
-    },
-    "has-binary2": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
-      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
-      "requires": {
-        "isarray": "2.0.1"
-      }
-    },
-    "has-cors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
     },
     "hashlru": {
       "version": "2.3.0",
@@ -839,15 +653,16 @@
       }
     },
     "hyperswarm-web": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hyperswarm-web/-/hyperswarm-web-1.0.3.tgz",
-      "integrity": "sha512-DxBGpmk2FoeZYcT/BNkmaVpMBuHECwjZzGFy+h6E7cyfo89TBOwDOYAJJ2W2oNJveoQg/fvtyg9tvcGxa0yzcQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/hyperswarm-web/-/hyperswarm-web-2.1.1.tgz",
+      "integrity": "sha512-uHVIN3ic6Dy5U6xx6pzf0F3WcJ+8clzrk6duZXPltKsHyv619cAO5j62tE+BdDzyzsuDP6bshnvIv+VW7s/vww==",
       "requires": {
-        "@geut/discovery-swarm-webrtc": "^2.2.4",
+        "@geut/discovery-swarm-webrtc": "^4.0.1",
         "duplexpair": "^1.0.1",
-        "hyperswarm-proxy-ws": "^1.0.0",
+        "hyperswarm-proxy-ws": "^1.2.0",
         "minimist": "^1.2.0",
-        "send": "^0.17.1"
+        "send": "^0.17.1",
+        "websocket-stream": "^5.5.2"
       }
     },
     "ieee754": {
@@ -860,11 +675,6 @@
       "resolved": "https://registry.npmjs.org/increment-buffer/-/increment-buffer-1.0.1.tgz",
       "integrity": "sha1-ZQdtdRidgIs5rROrW5WOBSFvng0=",
       "dev": true
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "inflight": {
       "version": "1.0.6",
@@ -936,9 +746,14 @@
       "dev": true
     },
     "isarray": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-      "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
     },
     "json-buffer": {
       "version": "2.0.11",
@@ -988,19 +803,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-    },
-    "mime-db": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
-    },
-    "mime-types": {
-      "version": "2.1.28",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
-      "requires": {
-        "mime-db": "1.45.0"
-      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1088,14 +890,43 @@
       "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
       "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
     },
-    "nanobus": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/nanobus/-/nanobus-4.4.0.tgz",
-      "integrity": "sha512-Hv9USGyH8EsPy0o8pPWE7x3YRIfuZDgMBirzjU6XLebhiSK2g53JlfqgolD0c39ne6wXAfaBNcIAvYe22Bav+Q==",
+    "nanocustomassert": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nanocustomassert/-/nanocustomassert-1.0.0.tgz",
+      "integrity": "sha512-oIezVMlrrzPkCtK32NM5y4gU7JPi12NPWrIsXLyH7KL2D3IFYCtNEHSNgabBzoXCMkXI8AO6SMBUSPvJVf6NCA=="
+    },
+    "nanoerror": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/nanoerror/-/nanoerror-1.2.1.tgz",
+      "integrity": "sha512-pCXtdyUZUqkyJjrfKxSMCzdblgVbXOXPdFC+Th80IuQzuoaSwLmMu8rJID92VStrv7sMyqMj86PJMoj//bKcsg==",
       "requires": {
-        "nanoassert": "^1.1.0",
-        "nanotiming": "^7.2.0",
-        "remove-array-items": "^1.0.0"
+        "quick-format-unescaped": "^3.0.3"
+      }
+    },
+    "nanomessage": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/nanomessage/-/nanomessage-8.2.0.tgz",
+      "integrity": "sha512-8MH6xggcEFhEJ2LvKx3PR3ygjgpjSVRrgmtBTeFodXCOLK7kXFlFcVq6vr+uu37MQcc3EBNZ4cP8uMsjfSJy/Q==",
+      "requires": {
+        "fastq": "^1.8.0",
+        "nanocustomassert": "^1.0.0",
+        "nanoerror": "^1.1.0",
+        "nanoresource-promise": "^2.0.0",
+        "varint": "^5.0.0"
+      }
+    },
+    "nanomessage-rpc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/nanomessage-rpc/-/nanomessage-rpc-3.0.0.tgz",
+      "integrity": "sha512-z8ymZCKmhoaLB8/rz7DnKaywlcOtjJOoOIcwoIvTRQlKdUFi4CwUyPjVeZy4Jdt5sQ52xC/oJGjmR7AXMc8urA==",
+      "requires": {
+        "emittery": "^0.6.0",
+        "end-of-stream": "^1.4.4",
+        "nanocustomassert": "^1.0.0",
+        "nanoerror": "^1.1.0",
+        "nanomessage": "^8.2.0",
+        "nanoresource-promise": "^2.0.0",
+        "varint": "^5.0.0"
       }
     },
     "nanoresource": {
@@ -1113,32 +944,15 @@
         }
       }
     },
-    "nanoscheduler": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/nanoscheduler/-/nanoscheduler-1.0.3.tgz",
-      "integrity": "sha512-jBbrF3qdU9321r8n9X7yu18DjP31Do2ItJm3mWrt90wJTrnDO+HXpoV7ftaUglAtjgj9s+OaCxGufbvx6pvbEQ==",
-      "requires": {
-        "nanoassert": "^1.1.0"
-      }
-    },
-    "nanotiming": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/nanotiming/-/nanotiming-7.3.1.tgz",
-      "integrity": "sha512-l3lC7v/PfOuRWQa8vV29Jo6TG10wHtnthLElFXs4Te4Aas57Fo4n1Q8LH9n+NDh9riOzTVvb2QNBhTS4JUKNjw==",
-      "requires": {
-        "nanoassert": "^1.1.0",
-        "nanoscheduler": "^1.0.2"
-      }
+    "nanoresource-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoresource-promise/-/nanoresource-promise-2.0.0.tgz",
+      "integrity": "sha512-C4nHaVqhpRYaSiKfXPC3bOiz5mnS3N1gkDhGaWmYLxr4KTAQdWqOr2pEVw4xVmAHJgA9n9anbfuVOacS/skbIA=="
     },
     "napi-macros": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
       "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
-    },
-    "negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "node-gyp-build": {
       "version": "3.3.0",
@@ -1181,20 +995,26 @@
       "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
       "dev": true
     },
-    "p-debounce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-debounce/-/p-debounce-2.1.0.tgz",
-      "integrity": "sha512-M9bMt62TTnozdZhqFgs+V7XD2MnuKCaz+7fZdlu2/T7xruI3uIE5CicQ0vx1hV7HIUYF0jF+4/R1AgfOkl74Qw=="
+    "p-event": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "requires": {
+        "p-timeout": "^3.1.0"
+      }
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
-    "p-forever": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-forever/-/p-forever-2.1.0.tgz",
-      "integrity": "sha512-kqZrNBsD8fUPCpZLYJoHTiONQVrdkA2nKwSsTfIr5h7P8jGpSy+Vzkxu6nVcZcz3c/rSx/Ys3AACd/BkMKvqbw=="
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
     },
     "p-queue": {
       "version": "6.6.2",
@@ -1212,16 +1032,6 @@
       "requires": {
         "p-finally": "^1.0.0"
       }
-    },
-    "parseqs": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
-      "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
-    },
-    "parseuri": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
-      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1343,6 +1153,11 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
       "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg=="
     },
+    "quick-format-unescaped": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
+      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -1371,26 +1186,21 @@
         "util-deprecate": "^1.0.1"
       }
     },
+    "reconnecting-websocket": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
+      "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng=="
+    },
     "record-cache": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.1.0.tgz",
       "integrity": "sha512-u8rbtLEJV7HRacl/ZYwSBFD8NFyB3PfTTfGLP37IW3hftQCwu6z4Q2RLyxo1YJUNRTEzJfpLpGwVuEYdaIkG9Q=="
-    },
-    "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "relative-url": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
       "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc=",
       "dev": true
-    },
-    "remove-array-items": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
-      "integrity": "sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA=="
     },
     "resolve": {
       "version": "1.5.0",
@@ -1409,6 +1219,11 @@
       "requires": {
         "through": "~2.3.4"
       }
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -1520,120 +1335,65 @@
         "readable-stream": "^3.6.0"
       }
     },
-    "simple-signal-client": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/simple-signal-client/-/simple-signal-client-2.3.1.tgz",
-      "integrity": "sha512-G1w2Ya4+scKah6mXkU6EZogo896uobgcnnWqgqYN1vJsF6o5IAjj9ZNSuoj82F9CNPSPKazie3Wmv+0eNYkVGQ==",
+    "simple-websocket": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-9.1.0.tgz",
+      "integrity": "sha512-8MJPnjRN6A8UCp1I+H/dSFyjwJhp6wta4hsVRhjf8w9qBHRzxYt14RaOcjvQnhD1N4yKOddEjflwMnQM4VtXjQ==",
       "requires": {
-        "babel-polyfill": "^6.23.0",
-        "cuid": "^2.0.2",
-        "inherits": "^2.0.3",
-        "nanobus": "^4.3.3",
+        "debug": "^4.3.1",
+        "queue-microtask": "^1.2.2",
+        "randombytes": "^2.1.0",
+        "readable-stream": "^3.6.0",
+        "ws": "^7.4.2"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+          "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
+        }
+      }
+    },
+    "socket-signal": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/socket-signal/-/socket-signal-9.0.0.tgz",
+      "integrity": "sha512-tnyvDFYI2+VgboN2oeCRCikyBmZwiZeXuQgt/th4PkyEcC+npGxOONfS9LGX9UH+/UEBDjnbW1ziRIs78Qn2jQ==",
+      "requires": {
+        "debug": "^4.1.1",
+        "end-of-stream": "^1.4.4",
+        "fastq": "^1.8.0",
+        "nanocustomassert": "^1.0.0",
+        "nanoerror": "^1.0.0",
+        "nanomessage-rpc": "^3.0.0",
+        "nanoresource-promise": "^2.0.0",
+        "p-event": "^4.1.0",
+        "p-limit": "^3.0.2",
         "simple-peer": "^9.6.2"
       }
     },
-    "simple-signal-server": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/simple-signal-server/-/simple-signal-server-2.1.2.tgz",
-      "integrity": "sha512-9754Rww59LSSXWH+DjnYzFBoFzxN9fY1vouqVeBs/YFpTycMCtYb1JHihzrBfmajaP5g9d/1rWOHS7svCyqbiA==",
+    "socket-signal-websocket": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/socket-signal-websocket/-/socket-signal-websocket-9.0.2.tgz",
+      "integrity": "sha512-oEZDCvmDCsI3fmJBXiATBUk3n0UZ6p5Q3OneWTJGk2QHghdtuiaRIUIW+VRD7okDXco8+O3h1qJ3R7g1o4QPBw==",
       "requires": {
-        "inherits": "^2.0.3",
-        "nanobus": "^4.3.3"
-      }
-    },
-    "socket.io": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.4.1.tgz",
-      "integrity": "sha512-Si18v0mMXGAqLqCVpTxBa8MGqriHGQh8ccEOhmsmNS3thNCGBwO8WGrwMibANsWtQQ5NStdZwHqZR3naJVFc3w==",
-      "requires": {
-        "debug": "~4.1.0",
-        "engine.io": "~3.5.0",
-        "has-binary2": "~1.0.2",
-        "socket.io-adapter": "~1.1.0",
-        "socket.io-client": "2.4.0",
-        "socket.io-parser": "~3.4.0"
+        "isomorphic-ws": "^4.0.1",
+        "minimist": "^1.2.5",
+        "nanocustomassert": "^1.0.0",
+        "reconnecting-websocket": "^4.4.0",
+        "simple-websocket": "^9.0.0",
+        "socket-signal": "^9.0.0",
+        "ws": "^7.2.3"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "socket.io-adapter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
-      "integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g=="
-    },
-    "socket.io-client": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.4.0.tgz",
-      "integrity": "sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==",
-      "requires": {
-        "backo2": "1.0.2",
-        "component-bind": "1.0.0",
-        "component-emitter": "~1.3.0",
-        "debug": "~3.1.0",
-        "engine.io-client": "~3.5.0",
-        "has-binary2": "~1.0.2",
-        "indexof": "0.0.1",
-        "parseqs": "0.0.6",
-        "parseuri": "0.0.6",
-        "socket.io-parser": "~3.3.0",
-        "to-array": "0.1.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "socket.io-parser": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
-          "integrity": "sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==",
-          "requires": {
-            "component-emitter": "~1.3.0",
-            "debug": "~3.1.0",
-            "isarray": "2.0.1"
-          }
-        }
-      }
-    },
-    "socket.io-parser": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.1.tgz",
-      "integrity": "sha512-11hMgzL+WCLWf1uFtHSNvliI++tcRUWdoeYuwIl+Axvwy9z2gQM+7nJyN3STj1tLj5JyIUH8/gpDGxzAlDdi0A==",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "~4.1.0",
-        "isarray": "2.0.1"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
+        "ws": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+          "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
         }
       }
     },
@@ -1797,11 +1557,6 @@
       "resolved": "https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-1.0.3.tgz",
       "integrity": "sha512-Mz0CX4vBGM5lj8ttbIFt7o4ZMxk/9rgudJRh76EvB7xXZMur7T/cjRiH2w4Fmkq0zxf2QpM8IFvOSRn8FEu3gA=="
     },
-    "to-array": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
-    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -1883,11 +1638,6 @@
         "xtend": "^4.0.0"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -1968,11 +1718,6 @@
         "ultron": "1.0.x"
       }
     },
-    "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
-    },
     "xor-distance": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xor-distance/-/xor-distance-2.0.0.tgz",
@@ -1983,10 +1728,10 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
-    "yeast": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -228,14 +228,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "dat-swarm-defaults": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dat-swarm-defaults/-/dat-swarm-defaults-1.0.1.tgz",
-      "integrity": "sha512-T2WlO7BVmN9USchefsP8entQiByIlJLGuzHLL9qEqOBkyKB8p0Y7XPWxP8dcL43+SkeoxU5NVe7O0bsi3xL8Jg==",
-      "requires": {
-        "xtend": "^4.0.1"
-      }
-    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,48 +1,130 @@
 {
   "name": "multiserver-dht",
-  "version": "3.3.1",
+  "version": "4.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@hyperswarm/dht": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@hyperswarm/dht/-/dht-4.0.1.tgz",
+      "integrity": "sha512-wMBbz0m8rgQMERt/Ot6BGo5Y8+ovJSZmqxF0oA2xYPT8vCVBIr8g2F1BkQcLbX2iKRLXRnhic02OEq8b41M0sw==",
+      "requires": {
+        "@hyperswarm/hypersign": "^2.0.0",
+        "dht-rpc": "^4.8.0",
+        "end-of-stream": "^1.4.1",
+        "guard-timeout": "^2.0.0",
+        "hashlru": "^2.3.0",
+        "protocol-buffers-encodings": "^1.1.0",
+        "record-cache": "^1.1.0",
+        "sodium-native": "^3.1.1"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+        },
+        "sodium-native": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
+          "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
+          "requires": {
+            "ini": "^1.3.5",
+            "node-gyp-build": "^4.2.0"
+          }
+        }
+      }
+    },
+    "@hyperswarm/discovery": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hyperswarm/discovery/-/discovery-2.0.1.tgz",
+      "integrity": "sha512-LM0DxxXYFEOZoUhN4g9VhHKGeM2mQIf8rnfSu/epBLmASAKNoKMijgGUZwhrh06wPROdBSJumjVzKl+8GPnRhA==",
+      "requires": {
+        "@hyperswarm/dht": "^4.0.0",
+        "multicast-dns": "^7.2.2",
+        "timeout-refresh": "^1.0.2"
+      }
+    },
+    "@hyperswarm/hypersign": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hyperswarm/hypersign/-/hypersign-2.1.1.tgz",
+      "integrity": "sha512-RcczqJsu2VScRoyJdLbxpYMBNq+73HJT3FVzDZXSOob/WqEeiN2WIvuDtvmFoufAuO/3YVfde/NpZFc/OPjmjw==",
+      "requires": {
+        "sodium-native": "^3.1.1"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+        },
+        "sodium-native": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
+          "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
+          "requires": {
+            "ini": "^1.3.5",
+            "node-gyp-build": "^4.2.0"
+          }
+        }
+      }
+    },
+    "@hyperswarm/network": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hyperswarm/network/-/network-2.1.0.tgz",
+      "integrity": "sha512-TvRRRd//a3q+JhpSh5PaHJfnP4oLM/0eZikyDh2Z+eaJpIZP+vZwdlpPd10neTsPq1zfJX8weRjYLFHNpoMZVg==",
+      "requires": {
+        "@hyperswarm/discovery": "^2.0.0",
+        "nanoresource": "^1.3.0",
+        "utp-native": "^2.2.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "bencode": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bencode/-/bencode-1.0.0.tgz",
-      "integrity": "sha512-N+VOSP5MkoX+xgnp6Y056iCY5TmCZg9rgPNPQe0bIiXchxYFP4vs/Tf0dTdQ+qQhP7HM2gvfFq+sUVjQsGy5Zw==",
+    "blake2b": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.3.tgz",
+      "integrity": "sha512-pkDss4xFVbMb4270aCyGD3qLv92314Et+FsKzilCLxDz5DuZ2/1g3w4nmBbu6nKApPspnjG7JcwTjGZnduB1yg==",
       "requires": {
-        "safe-buffer": "^5.1.1"
+        "blake2b-wasm": "^1.1.0",
+        "nanoassert": "^1.0.0"
       }
     },
-    "bittorrent-dht": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-7.10.0.tgz",
-      "integrity": "sha512-fvb6M58Ceiv/S94nu6zeaiMoJvUYOeIqRbgaClm+kJTzCAqJPtAR/31pXNYB5iEReOoKqQB5zY33gY0W6ZRWQQ==",
+    "blake2b-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/blake2b-universal/-/blake2b-universal-1.0.1.tgz",
+      "integrity": "sha512-vmMqpF8E9RCde8/+Su/s2rZRxOBwAYQsTyCgok4kLWhWrzMrX0CzID6pVheNJSESY0S0FNTOG4QfRJqnSLOjFA==",
       "requires": {
-        "bencode": "^1.0.0",
-        "buffer-equals": "^1.0.3",
-        "debug": "^3.1.0",
-        "inherits": "^2.0.1",
-        "k-bucket": "^3.3.0",
-        "k-rpc": "^4.2.1",
-        "lru": "^3.1.0",
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.0.1",
-        "simple-sha1": "^2.1.0"
+        "blake2b": "^2.1.3",
+        "sodium-native": "^3.0.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+        "node-gyp-build": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+        },
+        "sodium-native": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
+          "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
           "requires": {
-            "ms": "2.0.0"
+            "ini": "^1.3.5",
+            "node-gyp-build": "^4.2.0"
           }
         }
+      }
+    },
+    "blake2b-wasm": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-1.1.7.tgz",
+      "integrity": "sha512-oFIHvXhlz/DUgF0kq5B1CqxIDjIJwh9iDeUUGQUcvgiGz7Wdw03McEO7CfLBy7QKGdsydcMCgO9jFNBAFCtFcA==",
+      "requires": {
+        "nanoassert": "^1.0.0"
       }
     },
     "brace-expansion": {
@@ -54,16 +136,6 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
-    },
-    "buffer-equals": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz",
-      "integrity": "sha1-A1O1T9B/2VZBcGca5vZrnPENJ/U="
-    },
-    "buffer-from": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
     },
     "chloride": {
       "version": "2.2.8",
@@ -87,13 +159,10 @@
         "json-buffer": "^2.0.11"
       }
     },
-    "circular-append-file": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/circular-append-file/-/circular-append-file-1.0.1.tgz",
-      "integrity": "sha512-BUDFvrBTCdeVhg9E05PX4XgMegk6xWB69uGwyuATEg7PMfa9lGU1mzFSK0xWNW2O0i9CAQHN0oIdXI/kI2hPkg==",
-      "requires": {
-        "multistream": "^2.1.0"
-      }
+    "codecs": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/codecs/-/codecs-2.2.0.tgz",
+      "integrity": "sha512-+xi2ENsvchtUNa8oBUU58gHgmyN6BEEeZ8NIEgeQ0XnC+AoyihivgZYe+OOiNi+fLy/NUowugwV5gP8XWYDm0Q=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -101,30 +170,12 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "connections": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/connections/-/connections-1.4.2.tgz",
-      "integrity": "sha1-eJBIK/XHGvbFyhkr4xNq7XRCiq0="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
     "dat-swarm-defaults": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dat-swarm-defaults/-/dat-swarm-defaults-1.0.1.tgz",
       "integrity": "sha512-T2WlO7BVmN9USchefsP8entQiByIlJLGuzHLL9qEqOBkyKB8p0Y7XPWxP8dcL43+SkeoxU5NVe7O0bsi3xL8Jg==",
       "requires": {
         "xtend": "^4.0.1"
-      }
-    },
-    "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "requires": {
-        "ms": "2.0.0"
       }
     },
     "deep-equal": {
@@ -149,85 +200,46 @@
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
-    "discovery-channel": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/discovery-channel/-/discovery-channel-5.5.1.tgz",
-      "integrity": "sha512-EEmZQFE0PiOsJj7G3KVCwFGbYs4QchUvzA91iHtZ6HfkIqfBEDSTGLygJrUlY1Tr77WDV+qZVrZuNghHxSL/vw==",
+    "dht-rpc": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/dht-rpc/-/dht-rpc-4.9.6.tgz",
+      "integrity": "sha512-gzZPsesqOh0Lj0GxjbNhPe42tppSt9qpcMXifcwtr2i3WnhgyhjlXTFrq/po9kl4X98M7+RxwmzpXzPt7hcXwA==",
       "requires": {
-        "bittorrent-dht": "^7.10.0",
-        "buffer-from": "^1.0.0",
-        "debug": "^2.6.9",
-        "dns-discovery": "^6.0.1",
-        "pretty-hash": "^1.0.1",
-        "thunky": "^0.1.0"
-      }
-    },
-    "discovery-swarm": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/discovery-swarm/-/discovery-swarm-5.1.1.tgz",
-      "integrity": "sha512-r38993qP/fcuAlNLSOwGZUps1inzNA4wXkIkv/piwFDseyIWNjYyk/4DHGxyf/bWMB86gPWIUdA6AhydkWmgdA==",
-      "requires": {
-        "buffer-equals": "^1.0.3",
-        "connections": "^1.4.2",
-        "debug": "^2.4.5",
-        "discovery-channel": "^5.5.1",
-        "length-prefixed-message": "^3.0.3",
-        "pump": "^1.0.1",
-        "to-buffer": "^1.0.1",
-        "utp-native": "^1.7.0"
-      }
-    },
-    "dns-discovery": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/dns-discovery/-/dns-discovery-6.1.0.tgz",
-      "integrity": "sha512-Kl2tL2zuNR1w6SnsoRaqrOFm7gGP3/i/HzRXtyVBqaOq/5L1D2TUdViUAZ8e/NDbt+jQCJFWoaKCnmDC343usQ==",
-      "requires": {
-        "circular-append-file": "^1.0.1",
-        "debug": "^2.6.9",
-        "dns-socket": "^3.0.0",
-        "lru": "^2.0.0",
-        "minimist": "^1.2.0",
-        "multicast-dns": "^7.0.0",
-        "network-address": "^1.1.2",
-        "pump": "^3.0.0",
-        "speedometer": "^1.0.0",
-        "unordered-set": "^1.1.0"
+        "blake2b-universal": "^1.0.0",
+        "codecs": "^2.0.0",
+        "ipv4-peers": "^2.0.0",
+        "k-bucket": "^5.0.0",
+        "protocol-buffers-encodings": "^1.1.0",
+        "sodium-native": "^3.1.1",
+        "speedometer": "^1.1.0",
+        "stream-collector": "^1.0.1",
+        "time-ordered-set": "^1.0.1",
+        "xor-distance": "^2.0.0"
       },
       "dependencies": {
-        "lru": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lru/-/lru-2.0.1.tgz",
-          "integrity": "sha1-+XmHHhYuP1yiVL5GhExT1MU2RUQ=",
-          "requires": {
-            "inherits": "^2.0.1"
-          }
+        "node-gyp-build": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
         },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+        "sodium-native": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
+          "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "ini": "^1.3.5",
+            "node-gyp-build": "^4.2.0"
           }
         }
       }
     },
     "dns-packet": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.1.1.tgz",
-      "integrity": "sha512-YwtiH6TWoXGIVHE/UgorccaS9qStav9yO5ToMy6R3MdCt1YBdiBRykTguTV7vfhHSnSsZzlZ1jNzGqP7VsKmEg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.2.0.tgz",
+      "integrity": "sha512-bn1AKpfkFbm0MIioOMHZ5qJzl2uypdBwI4nYNsqvhjsegBhcKJUlCrMPWLx6JEezRjxZmxhtIz/FkBEur2l8Cw==",
       "requires": {
         "ip": "^1.1.5",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "dns-socket": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-3.0.0.tgz",
-      "integrity": "sha512-M0WkByoJ/mTm+HtwBQLsRJPe5uGIC/lYVOp+s6ZzhbZ5iq4GxjFyxYPQhB85dgCLvVb43aJQXHDC9aUgyKGc/Q==",
-      "requires": {
-        "dns-packet": "^4.1.0"
       }
     },
     "ed2curve": {
@@ -240,9 +252,9 @@
       }
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
       }
@@ -312,6 +324,11 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "guard-timeout": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/guard-timeout/-/guard-timeout-2.0.0.tgz",
+      "integrity": "sha512-35geHv72oal0cRUE5t1tZ5KHm3OVPXzFtiMG8AnRPV5FkkEf84RUpeQ0BCeCZunfSLGATW5ZVyALhJKgM7I/6A=="
+    },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -319,6 +336,21 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.0.2"
+      }
+    },
+    "hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
+    },
+    "hyperswarm": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-2.15.2.tgz",
+      "integrity": "sha512-4TrClGoKJWO+W3LV0bhFVqmt6iZvx4jU0lklqvfsWCXoI8WmdHDC1dXqxMvJlalA6HXJWctgbshKqz+CYUEbhg==",
+      "requires": {
+        "@hyperswarm/network": "^2.0.0",
+        "shuffled-priority-queue": "^2.1.0",
+        "utp-native": "^2.1.7"
       }
     },
     "increment-buffer": {
@@ -345,14 +377,17 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "ipv4-peers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ipv4-peers/-/ipv4-peers-2.0.0.tgz",
+      "integrity": "sha512-6ZMWB3JnCWT0gISUkzChcUEkJS6+LpGRU3h10f9Mfc0usVmyIcbcTN9+QPMg29gLOY8WtaKFbM5ME8qNySoh8g=="
     },
     "is-callable": {
       "version": "1.1.3",
@@ -393,11 +428,6 @@
       "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
     "json-buffer": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz",
@@ -405,64 +435,11 @@
       "dev": true
     },
     "k-bucket": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-3.3.1.tgz",
-      "integrity": "sha512-kgwWqYT79rAahn4maIVTP8dIe+m1KulufWW+f1bB9DlZrRFiGpZ4iJOg2HUp4xJYBWONP3+rOPIWF/RXABU6mw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-5.0.0.tgz",
+      "integrity": "sha512-r/q+wV/Kde62/tk+rqyttEJn6h0jR7x+incdMVSYTqK73zVxVrzJa70kJL49cIKen8XjIgUZKSvk8ktnrQbK4w==",
       "requires": {
-        "buffer-equals": "^1.0.3",
-        "inherits": "^2.0.1",
         "randombytes": "^2.0.3"
-      }
-    },
-    "k-rpc": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/k-rpc/-/k-rpc-4.3.1.tgz",
-      "integrity": "sha512-mgAJZeFYbpP0xzJzmS0TQTYoFI0sjy3GnKFhg8wyboL+KvWg2WLaA2Oy9PthLPx2Rxz4WeBMk4y3MSOrDJ95FA==",
-      "requires": {
-        "buffer-equals": "^1.0.3",
-        "k-bucket": "^4.0.0",
-        "k-rpc-socket": "^1.7.2",
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.1"
-      },
-      "dependencies": {
-        "k-bucket": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-4.0.0.tgz",
-          "integrity": "sha512-E+rLflXOUTxgG29NLjTSNZEGt1hcvV0pZqyhbhpiPk888xk/H1uXXX07Bu2eakL4+UH6Vae4t/opJejgf5wQCQ==",
-          "requires": {
-            "inherits": "^2.0.1",
-            "randombytes": "^2.0.3"
-          }
-        }
-      }
-    },
-    "k-rpc-socket": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.8.0.tgz",
-      "integrity": "sha512-f/9TynsO8YYjZ6JjNNtSSH7CJcIHcio1buy3zqByGxb/GX8AWLdL6FZEWTrN8V3/J7W4/E0ZTQQ+Jt2rVq7ELg==",
-      "requires": {
-        "bencode": "^2.0.0",
-        "buffer-equals": "^1.0.4",
-        "safe-buffer": "^5.1.1"
-      },
-      "dependencies": {
-        "bencode": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/bencode/-/bencode-2.0.0.tgz",
-          "integrity": "sha512-wr2HwwrUpfB5c68zmAudOltC7rZ1G0+lQOcnuEcfIM3AWAVnB3rHI3nlgd/2CWTfQ3w3zagKt89zni/M+VLZ8g==",
-          "requires": {
-            "safe-buffer": "^5.1.1"
-          }
-        }
-      }
-    },
-    "length-prefixed-message": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/length-prefixed-message/-/length-prefixed-message-3.0.3.tgz",
-      "integrity": "sha1-JFR01pq8BhTco2jcNaqAdJgqI6w=",
-      "requires": {
-        "varint": "^3.0.1"
       }
     },
     "libsodium": {
@@ -485,14 +462,6 @@
       "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
       "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
     },
-    "lru": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz",
-      "integrity": "sha1-6n+4VG2DczOWoTCR12z+tMBoN9U=",
-      "requires": {
-        "inherits": "^2.0.1"
-      }
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -505,27 +474,16 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-    },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "multicast-dns": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.0.0.tgz",
-      "integrity": "sha512-BqB5TtIXHo+8gN33N1CA1clsvPsAJlnc6D49SzfQA0xq75cxj15g2y9NaRdf4x2u4v1P66PBC+Wg6YgPO5Bc/g==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.2.tgz",
+      "integrity": "sha512-XqSMeO8EWV/nOXOpPV8ztIpNweVfE1dSpz6SQvDPp71HD74lMXjt4m/mWB1YBMG0kHtOodxRWc5WOb/UNN1A5g==",
       "requires": {
         "dns-packet": "^4.0.0",
         "thunky": "^1.0.2"
-      },
-      "dependencies": {
-        "thunky": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
-          "integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E="
-        }
       }
     },
     "multiserver": {
@@ -561,30 +519,43 @@
         }
       }
     },
-    "multistream": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multistream/-/multistream-2.1.0.tgz",
-      "integrity": "sha1-YlwmfVxEQkrWKUeItbtNo9yzLx0=",
-      "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.5"
-      }
-    },
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "dev": true,
       "optional": true
     },
-    "network-address": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/network-address/-/network-address-1.1.2.tgz",
-      "integrity": "sha1-Sqe/1D8D8LgclwKxPWqFjdsybz4="
+    "nanoassert": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+      "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
+    },
+    "nanoresource": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nanoresource/-/nanoresource-1.3.0.tgz",
+      "integrity": "sha512-OI5dswqipmlYfyL3k/YMm7mbERlh4Bd1KuKdMHpeoVD1iVxqxaTMKleB4qaA2mbQZ6/zMNSxCXv9M9P/YbqTuQ==",
+      "requires": {
+        "inherits": "^2.0.4"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
+      }
+    },
+    "napi-macros": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
     },
     "node-gyp-build": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.3.0.tgz",
       "integrity": "sha512-SNtBzznpPggc7mY8XTfnYBywd9OGN99bwnxGKFqud9erYJMbwnJn6B8HXER2dy8iOYr6Nf2SzBQoJjV8gdM4Nw==",
+      "dev": true,
       "optional": true
     },
     "object-inspect": {
@@ -625,15 +596,14 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
-    "pretty-hash": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pretty-hash/-/pretty-hash-1.0.1.tgz",
-      "integrity": "sha1-FuBXkYje9WvbVliSvNBaXWUySAc="
-    },
-    "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    "protocol-buffers-encodings": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-encodings/-/protocol-buffers-encodings-1.1.1.tgz",
+      "integrity": "sha512-5aFshI9SbhtcMiDiZZu3g2tMlZeS5lhni//AGJ7V34PQLU5JA91Cva7TIs6inZhYikS3OpnUzAUuL6YtS0CyDA==",
+      "requires": {
+        "signed-varint": "^2.0.1",
+        "varint": "5.0.0"
+      }
     },
     "pull-box-stream": {
       "version": "1.0.13",
@@ -710,36 +680,28 @@
         "ws": "^1.1.0"
       }
     },
-    "pump": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "randombytes": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "requires": {
         "safe-buffer": "^5.1.0"
       }
     },
     "readable-stream": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.0.3",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
+    },
+    "record-cache": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.1.0.tgz",
+      "integrity": "sha512-u8rbtLEJV7HRacl/ZYwSBFD8NFyB3PfTTfGLP37IW3hftQCwu6z4Q2RLyxo1YJUNRTEzJfpLpGwVuEYdaIkG9Q=="
     },
     "relative-url": {
       "version": "1.0.2",
@@ -764,11 +726,6 @@
       "requires": {
         "through": "~2.3.4"
       }
-    },
-    "rusha": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/rusha/-/rusha-0.8.13.tgz",
-      "integrity": "sha1-mghOe4YLF7/zAVuSxnpqM2GRUTo="
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -803,12 +760,20 @@
         "inherits": "^2.0.1"
       }
     },
-    "simple-sha1": {
+    "shuffled-priority-queue": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.0.tgz",
-      "integrity": "sha1-lCe7lv8SY8wQqEFM7dUaGLkZ6LM=",
+      "resolved": "https://registry.npmjs.org/shuffled-priority-queue/-/shuffled-priority-queue-2.1.0.tgz",
+      "integrity": "sha512-xhdh7fHyMsr0m/w2kDfRJuBFRS96b9l8ZPNWGaQ+PMvnUnZ/Eh+gJJ9NsHBd7P9k0399WYlCLzsy18EaMfyadA==",
       "requires": {
-        "rusha": "^0.8.1"
+        "unordered-set": "^2.0.1"
+      }
+    },
+    "signed-varint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
+      "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
+      "requires": {
+        "varint": "~5.0.0"
       }
     },
     "sodium-browserify": {
@@ -866,15 +831,23 @@
       }
     },
     "speedometer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
-      "integrity": "sha1-zWccsGdSwivKM3Di8zREC+T8YuI="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.1.0.tgz",
+      "integrity": "sha512-z/wAiTESw2XVPssY2XRcme4niTc4S5FkkJ4gknudtVoc33Zil8TdTxHy5torRcgqMqksJV2Yz8HQcvtbsnw0mQ=="
     },
     "split-buffer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/split-buffer/-/split-buffer-1.0.0.tgz",
       "integrity": "sha1-t+jgq1E0UVi3LB9tvvJAbVHx0Cc=",
       "dev": true
+    },
+    "stream-collector": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-collector/-/stream-collector-1.0.1.tgz",
+      "integrity": "sha1-TU5V8XE1YSGyxfZVn5RHBaso2xU=",
+      "requires": {
+        "once": "^1.3.1"
+      }
     },
     "stream-to-pull-stream": {
       "version": "1.7.2",
@@ -897,11 +870,18 @@
       }
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
       }
     },
     "tape": {
@@ -932,14 +912,19 @@
       "dev": true
     },
     "thunky": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
-      "integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4="
-    },
-    "to-buffer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.0.tgz",
-      "integrity": "sha1-N1vAPtrlw1qPoLP+laHzmF2x3Po="
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+    },
+    "time-ordered-set": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/time-ordered-set/-/time-ordered-set-1.0.2.tgz",
+      "integrity": "sha512-vGO99JkxvgX+u+LtOKQEpYf31Kj3i/GNwVstfnh4dyINakMgeZCpew1e3Aj+06hEslhtHEd52g7m5IV+o1K8Mw=="
+    },
+    "timeout-refresh": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-1.0.3.tgz",
+      "integrity": "sha512-Mz0CX4vBGM5lj8ttbIFt7o4ZMxk/9rgudJRh76EvB7xXZMur7T/cjRiH2w4Fmkq0zxf2QpM8IFvOSRn8FEu3gA=="
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -963,9 +948,9 @@
       "dev": true
     },
     "unordered-set": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unordered-set/-/unordered-set-1.1.0.tgz",
-      "integrity": "sha1-K6fvMW7dC5WQzFR8dPdqLxZP7Mo="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unordered-set/-/unordered-set-2.0.1.tgz",
+      "integrity": "sha512-eUmNTPzdx+q/WvOHW0bgGYLWvWHNT3PTKEQLg0MAQhc0AHASHVHoP/9YytYd4RBVariqno/mEUhVZN98CmD7bg=="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -973,20 +958,28 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utp-native": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-1.7.0.tgz",
-      "integrity": "sha512-34NYDBJdTzOk/DwuEgE2vS1krfYihj4BiiZGjgfN2j8CzjhZeumXW63hwi8bneXU8fymUajRQIR4A4opXzEGWg==",
-      "optional": true,
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-2.2.2.tgz",
+      "integrity": "sha512-xwn5neM3aKgRCNYaiENRf2pwPa2G79O7r+OCZJDiy92x2q58Ez9hFUPeAW0IQcv0Ii5l1ytDIFWWyaiYVOtlng==",
       "requires": {
-        "nan": "^2.5.1",
-        "node-gyp-build": "^3.0.0",
-        "readable-stream": "^2.2.2"
+        "napi-macros": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.0.2",
+        "timeout-refresh": "^1.0.0",
+        "unordered-set": "^2.0.1"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+        }
       }
     },
     "varint": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-3.0.1.tgz",
-      "integrity": "sha1-nT9T4DbAqxIACnS8LSTL8JOlgdk="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
+      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
     },
     "wrappy": {
       "version": "1.0.2",
@@ -1002,6 +995,11 @@
         "options": ">=0.0.5",
         "ultron": "1.0.x"
       }
+    },
+    "xor-distance": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xor-distance/-/xor-distance-2.0.0.tgz",
+      "integrity": "sha512-AsAqZfPAuWx7qB/0kyRDUEvoU3QKsHWzHU9smFlkaiprEpGfJ/NBbLze2Uq0rdkxCxkNM9uOLvz/KoNBCbZiLQ=="
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "dat-swarm-defaults": "^1.0.1",
-    "discovery-swarm": "~6.0.0",
+    "hyperswarm": "^2.15.2",
     "pull-stream": "^3.6.9",
     "stream-to-pull-stream": "1.7.x"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "dat-swarm-defaults": "^1.0.1",
     "hyperswarm": "^2.15.2",
+    "hyperswarm-web": "^1.0.1",
     "pull-stream": "^3.6.9",
     "stream-to-pull-stream": "1.7.x"
   },
@@ -25,5 +26,8 @@
     "multiserver": "^1.13.4",
     "pull-pushable": "^2.2.0",
     "tape": "^4.8.0"
+  },
+  "browser": {
+    "hyperswarm": "hyperswarm-web"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "dat-swarm-defaults": "^1.0.1",
     "hyperswarm": "^2.15.2",
-    "hyperswarm-web": "^1.0.1",
+    "hyperswarm-web": "^2.1.1",
     "pull-stream": "^3.6.9",
     "stream-to-pull-stream": "1.7.x"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "node": ">=6"
   },
   "dependencies": {
-    "dat-swarm-defaults": "^1.0.1",
     "hyperswarm": "^2.15.2",
     "hyperswarm-web": "^2.1.1",
     "pull-stream": "^3.6.9",


### PR DESCRIPTION
My attempt at porting to Hyperswarm.  (I don't have a second computer handy to try to test this from, so I'm hoping this works.)

I changed example-s.js from using "keys" to using a single "key" because there is an issue (present in master as well) where it actually spins up servers on each *letter* of each key rather than each key as a whole.  That will need to be fixed, too, but in the meantime this change should allow for proper testing in the method that's most normally used.